### PR TITLE
ci: fix publish action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,10 +40,9 @@ jobs:
 
       - name: Publish for ${{ matrix.rid }}
         run: |
-          dotnet publish src/Chirp.CLI/Chirp.CLI.csproj \
+          dotnet publish \
             -c Release \
             -r ${{ matrix.rid }} \
-            -p:PublishSingleFile=false \
             -o publish/${{ matrix.rid }}
 
       - name: Ensure executable bit (Linux/macOS only)


### PR DESCRIPTION
This should fix the automated publishing of our dotnet program, which broke due to an oversight where we forgot updating our release action when switching to Chirp.Razor.
It should also survive further refactors as we no longer hard code publishing Chirp.CLI.
