### PR TITLE
fix: restore support for running on windows

### DIFF
--- a/src/Chirp.SQLite/DBFacade.cs
+++ b/src/Chirp.SQLite/DBFacade.cs
@@ -10,9 +10,10 @@ namespace Chirp.SQLite
 
         public DBFacade()
         {
+            string defaultDBPath = Path.Combine(Path.GetTempPath(), "chirp.db");
             // Use CHIRPDBPATH from env if present
             string? dbPathFromEnv = Environment.GetEnvironmentVariable("CHIRPDBPATH");
-            _sqlDBFilePath = string.IsNullOrEmpty(dbPathFromEnv) ? "/tmp/chirp.db" : dbPathFromEnv;
+            _sqlDBFilePath = string.IsNullOrEmpty(dbPathFromEnv) ? defaultDBPath : dbPathFromEnv;
 
             if (!File.Exists(_sqlDBFilePath))
             {


### PR DESCRIPTION
More or less the title. This restores support for windows by using Path.GetTempPath(), which handles temp dir in a cross platform way.

Before merging, could a windows user please test this

@Mattschoe
