### PR TITLE
refactor: Moved pagination into querying

### DIFF
--- a/src/Chirp.Models/Models/IChirpFacade.cs
+++ b/src/Chirp.Models/Models/IChirpFacade.cs
@@ -2,7 +2,22 @@ namespace Chirp.Models
 {
     public interface IChirpFacade
     {
-        IEnumerable<CheepViewModel> Read(string? user = null, int n = 0);
+        /// <summary>
+        /// Returns a single page cheeps
+        /// </summary>
+        /// <param name="pagenum">Which page of cheeps is wished for (the higher the older cheeps)</param>
+        /// <returns></returns>
+        IEnumerable<CheepViewModel> ReadPage(int pagenum = 0);
+        /// <summary>
+        /// Returns a single page of cheeps from a given author
+        /// </summary>
+        /// <param name="username">The author of the cheeps</param>
+        /// <param name="pagenum">Which page of cheeps is wished for (the higher the older cheeps)</param>
+        /// <returns></returns>
+        IEnumerable<CheepViewModel> ReadPageFromAuthor(string username, int pagenum = 0);
+        /// <summary>
+        /// Inserts a cheep into the database
+        /// </summary>
         void Create(CheepViewModel cheep);
     }
 }

--- a/src/Chirp.Razor/CheepService.cs
+++ b/src/Chirp.Razor/CheepService.cs
@@ -9,7 +9,7 @@ public interface ICheepService
 public class CheepService : ICheepService
 {
     private static readonly IChirpFacade _db = new DBFacade();
-    
+
     /// Returns at most N cheeps from public timeline
     public List<CheepViewModel> GetCheeps(int pagenum)
     {

--- a/src/Chirp.Razor/CheepService.cs
+++ b/src/Chirp.Razor/CheepService.cs
@@ -9,44 +9,16 @@ public interface ICheepService
 public class CheepService : ICheepService
 {
     private static readonly IChirpFacade _db = new DBFacade();
-
-    // Limit the amount of Cheeps displayed at any given time. Set to 4 for testing easier purposes
-    private int _limit = 32;
-
-    // Returns at most N cheeps from public timeline
+    
+    /// Returns at most N cheeps from public timeline
     public List<CheepViewModel> GetCheeps(int pagenum)
     {
-        IEnumerable<CheepViewModel> cheeps = _db.Read();
-
-        // If collection is empty or null, return empty list.
-        if (cheeps == null)
-        {
-            return new List<CheepViewModel>();
-        }
-
-        // Uses list as IEnumerable to not nuke memory usage for large collections.
-        try
-        {
-            return cheeps.Skip(pagenum * _limit).Take(_limit).ToList();
-        }
-        catch (ArgumentNullException e)
-        {
-            Console.WriteLine(e.Message);
-            return new List<CheepViewModel>();
-        }
+        return _db.ReadPage(pagenum).ToList();
     }
 
-    // Returns at most N Cheeps from author
+    /// Returns at most N Cheeps from author
     public List<CheepViewModel> GetCheepsFromAuthor(string author, int pagenum)
     {
-        IEnumerable<CheepViewModel> cheeps = _db.Read();
-
-        // If collection is empty or null, return empty list.
-        if (cheeps == null)
-        {
-            return new List<CheepViewModel>();
-        }
-
-        return cheeps.Where(x => x.Author == author).Skip(pagenum * _limit).Take(_limit).ToList();
+        return _db.ReadPageFromAuthor(author, pagenum).ToList();
     }
 }

--- a/src/Chirp.SQLite/DBFacade.cs
+++ b/src/Chirp.SQLite/DBFacade.cs
@@ -8,7 +8,7 @@ namespace Chirp.SQLite
     public class DBFacade : IChirpFacade
     {
         private readonly string _sqlDBFilePath;
-        private readonly int readLimit = 32;
+        private readonly int _readLimit = 32;
 
         public DBFacade()
         {
@@ -87,8 +87,8 @@ namespace Chirp.SQLite
             using var connection = new SqliteConnection($"Data Source={_sqlDBFilePath}");
             using var command = connection.CreateCommand();
             command.CommandText = queryString;
-            command.Parameters.AddWithValue("@limit", readLimit);
-            command.Parameters.AddWithValue("@offset", pagenum * readLimit);
+            command.Parameters.AddWithValue("@limit", _readLimit);
+            command.Parameters.AddWithValue("@offset", pagenum * _readLimit);
 
             connection.Open();
 
@@ -122,8 +122,8 @@ namespace Chirp.SQLite
             using var command = connection.CreateCommand();
             command.CommandText = queryString;
             command.Parameters.AddWithValue("@username", username);
-            command.Parameters.AddWithValue("@limit", readLimit);
-            command.Parameters.AddWithValue("@offset", pagenum * readLimit);
+            command.Parameters.AddWithValue("@limit", _readLimit);
+            command.Parameters.AddWithValue("@offset", pagenum * _readLimit);
 
             connection.Open();
 

--- a/src/Chirp.SQLite/DBFacade.cs
+++ b/src/Chirp.SQLite/DBFacade.cs
@@ -88,7 +88,7 @@ namespace Chirp.SQLite
             using var command = connection.CreateCommand();
             command.CommandText = queryString;
             command.Parameters.AddWithValue("@limit", readLimit);
-            command.Parameters.AddWithValue("@offset", pagenum*readLimit);
+            command.Parameters.AddWithValue("@offset", pagenum * readLimit);
 
             connection.Open();
 
@@ -123,7 +123,7 @@ namespace Chirp.SQLite
             command.CommandText = queryString;
             command.Parameters.AddWithValue("@username", username);
             command.Parameters.AddWithValue("@limit", readLimit);
-            command.Parameters.AddWithValue("@offset", pagenum*readLimit);
+            command.Parameters.AddWithValue("@offset", pagenum * readLimit);
 
             connection.Open();
 
@@ -141,7 +141,7 @@ namespace Chirp.SQLite
             }
             return results;
         }
-        
+
         private static string UnixTimeStampToDateTimeString(double unixTimeStamp)
         {
             // Unix timestamp is seconds past epoch

--- a/test/Chirp.SQLite.Tests/ChirpSQLiteTests.cs
+++ b/test/Chirp.SQLite.Tests/ChirpSQLiteTests.cs
@@ -52,7 +52,7 @@ public class ChirpSQLiteTests
     [Fact]
     public void ReadAllMessageTest()
     {
-        List<CheepViewModel> cheeps = _db.Read().ToList();
+        List<CheepViewModel> cheeps = _db.ReadPage().ToList();
 
         Assert.Equal("hello world", cheeps[0].Message);
         Assert.Equal("Jacqualine Gilcoine", cheeps[0].Author);
@@ -65,25 +65,9 @@ public class ChirpSQLiteTests
     }
 
     [Fact]
-    public void ReadSomeMessageTest()
-    {
-        List<CheepViewModel> cheeps = _db.Read(null, 1).ToList();
-
-        Assert.Equal("hello world", cheeps[0].Message);
-        Assert.Equal("Jacqualine Gilcoine", cheeps[0].Author);
-
-        Assert.Single(cheeps);
-
-        Assert.Throws<ArgumentOutOfRangeException>(() =>
-        {
-            CheepViewModel cheep = cheeps[2];
-        });
-    }
-
-    [Fact]
     public void ReadUserMessagesTest()
     {
-        List<CheepViewModel> cheeps = _db.Read("Karl Fortnite", 0).ToList();
+        List<CheepViewModel> cheeps = _db.ReadPageFromAuthor("Karl Fortnite").ToList();
 
         Assert.Equal("I love Fortnite", cheeps[0].Message);
         Assert.Equal("Karl Fortnite", cheeps[0].Author);
@@ -102,7 +86,7 @@ public class ChirpSQLiteTests
         var newCheep = new CheepViewModel("Karl Fortnite", "Mannnnnnn I Love Fortnite", "1490895677");
         _db.Create(newCheep);
 
-        List<CheepViewModel> cheeps = _db.Read("Karl Fortnite", 0).ToList();
+        List<CheepViewModel> cheeps = _db.ReadPageFromAuthor("Karl Fortnite").ToList();
 
         Assert.False(1 == cheeps.Count);
 


### PR DESCRIPTION
This change also refactors IChirpFacade to better follow normal database standards of one method for one query, instead of more general queries. 

Removed a test since it didnt make sense to only retrieve "some" chirps. We always want atleast a page worth of cheeps.  ReadLimit is now defined in the DBFacade and our Cheepservice just asks for a "page" in the DB