### PR TITLE
add typescript support to chirp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ data/chirp.db-wal
 data/chirp.db-shm
 data/chirp.db
 src/Chirp.Web/chirp.db
+
+# Typescript scriptlets
+**/wwwroot/js/*

--- a/src/Chirp.Web/Chirp.Web.csproj
+++ b/src/Chirp.Web/Chirp.Web.csproj
@@ -25,6 +25,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="5.9.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.7" />
   </ItemGroup>
 

--- a/src/Chirp.Web/scripts/app.ts
+++ b/src/Chirp.Web/scripts/app.ts
@@ -1,0 +1,4 @@
+// Placeholder function
+function foo() {
+  console.warn("Here be dragons")
+}

--- a/src/Chirp.Web/tsconfig.json
+++ b/src/Chirp.Web/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compileOnSave": true,
+  "compilerOptions": {
+    "noImplicitAny": false,
+    "noEmitOnError": true,
+    "removeComments": false,
+    "sourceMap": true,
+    "target": "ES6",
+    "outDir": "wwwroot/js"
+  },
+  "include": [
+    "scripts/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "wwwroot"
+  ]
+}


### PR DESCRIPTION
As discussed earlier today, this pr adds support for typescript in Chirp.Web.
This is needed for client-side scripting, which is needed for prompts such as editing cheeps or replying cheeps (It could also be used for a nicer post ui).
Typescript was chosen over javascript, as we, after long deliberation, decided that the added safety of typescripts type checker was valuable.

Documentation for how to add a scriptlet to a page can be found [here](https://learn.microsoft.com/en-us/visualstudio/javascript/tutorial-aspnet-with-typescript?view=vs-2022)
